### PR TITLE
fix: pin third-party actions to SHA, quote Dockerfile vars, broaden Sonar triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
             go:
@@ -93,7 +93,7 @@ jobs:
           check-latest: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.10.1
 
@@ -174,21 +174,21 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Read version
         id: version
         run: echo "version=$(cat .version)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     outputs:
       go: ${{ steps.filter.outputs.go }}
+      sonar: ${{ steps.filter.outputs.sonar }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -44,6 +45,19 @@ jobs:
               - 'go.sum'
               - 'Makefile'
               - '.golangci.yml'
+            # SonarCloud analyses more than Go: workflows, Dockerfiles, the Hugo
+            # site, and the analysis config are all in scope, so the scan must
+            # run when any of these change, not just on Go changes.
+            sonar:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.golangci.yml'
+              - '.github/workflows/**'
+              - '**/Dockerfile'
+              - 'web/**'
+              - 'sonar-project.properties'
 
   # ---------------------------------------------------------------------------
   # GO CHECKS
@@ -138,7 +152,7 @@ jobs:
   # ---------------------------------------------------------------------------
   sonarqube:
     needs: [changes]
-    if: needs.changes.outputs.go == 'true'
+    if: needs.changes.outputs.sonar == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: make prep-changelog
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           version: "~> v2"
           args: release --clean
@@ -69,12 +69,12 @@ jobs:
           GOTOOLCHAIN: go1.26.4
 
       - name: Install git-cliff
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           args: --version
 
       - name: Generate CHANGELOG.md
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           args: -o CHANGELOG.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 
 # --- Build binary (native cross-compilation, no QEMU needed) ---
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build \
     -ldflags="-s -w -X github.com/afreidah/oracle-watchdog/internal/tracing.Version=${VERSION}" \
     -o oracle-watchdog ./cmd/watchdog
 


### PR DESCRIPTION
## Summary

Clears the remaining SonarCloud findings on `main` and fixes a gap where workflow/Dockerfile/web changes never triggered a Sonar re-scan.

## Findings fixed
- **8 security hotspots (githubactions:S7637)** — pinned all third-party GitHub Actions to full commit SHAs (dorny/paths-filter, golangci-lint-action, docker/{login,setup-buildx,build-push}, goreleaser, git-cliff), matching the sibling repos. Trusted `actions/*` references stay on version tags.
- **2 maintainability issues (docker:S6570)** — quoted `${TARGETOS}`/`${TARGETARCH}` in the Dockerfile build step.

## CI improvement
The `sonarqube` job was gated on `needs.changes.outputs.go == 'true'`, so YAML/Dockerfile/web-only changes never got re-analyzed. Added a broader `sonar` path filter (workflows, Dockerfiles, `web/**`, `sonar-project.properties`) and gated the scan on it — so this very PR runs the scan and future non-Go changes do too.

## Test plan
- YAML validates; all third-party actions confirmed SHA-pinned (only `actions/*` remain on tags).
- The sonarqube job now runs on this PR (workflow + Dockerfile changes).