### PR TITLE
ci: skip sonarqube job for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,10 @@ jobs:
   # ---------------------------------------------------------------------------
   sonarqube:
     needs: [changes]
-    if: needs.changes.outputs.sonar == 'true'
+    # Skip for Dependabot: its PRs run without repository secrets, so SONAR_TOKEN
+    # is unavailable and the scan can't authenticate. Dependency bumps add no
+    # analysable code; the next push to main re-scans.
+    if: needs.changes.outputs.sonar == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Dependabot PRs run without access to repository secrets (a GitHub security measure), so `SONAR_TOKEN` is empty and the `sonarqube` scan fails to authenticate (`Not authorized or project not found`). This made the consul/api bump PR (#61) show a failing check despite the bump itself being fine.

Guard the `sonarqube` job with `github.actor != 'dependabot[bot]'` so it's skipped on Dependabot PRs — matching the pattern in the s3-orchestrator repo. Dependency bumps add no analysable code, and the next push to `main` re-scans.

## Test plan
- YAML validates.
- After merge, recreating #61 should show the sonarqube job skipped and all other checks green.