### PR TITLE
fix(web): restore architecture page hover tooltips for Mermaid 11

### DIFF
--- a/web/content/docs/architecture.md
+++ b/web/content/docs/architecture.md
@@ -108,7 +108,11 @@ weight: 5
     var tooltip = document.getElementById('arch-tooltip');
     document.querySelectorAll('#arch-diagram .node').forEach(function(node) {
       var id = node.id || '';
-      var key = id.replace(/^flowchart-/, '').replace(/-\d+$/, '');
+      // Mermaid 11 prefixes node ids with the render id, e.g.
+      // "arch-mermaid-svg-flowchart-ON1-0"; older versions emitted a bare
+      // "flowchart-ON1-0". Pull the node key out of either form.
+      var match = id.match(/flowchart-(.+?)-\d+$/);
+      var key = match ? match[1] : '';
       if (!nodeInfo[key]) return;
 
       node.addEventListener('mouseenter', function(e) {


### PR DESCRIPTION
## Problem

Hover tooltips on the [Architecture page](web/content/docs/architecture.md) stopped showing.

## Cause

The page renders its own Mermaid diagram and wires hover tooltips by matching each SVG node's `id`. Mermaid 11 changed the node-id format to prefix it with the render id:

- **Old:** `flowchart-ON1-0`
- **Mermaid 11:** `arch-mermaid-svg-flowchart-ON1-0`

The wiring used `id.replace(/^flowchart-/, '')`, anchored at the start of the string, so it no longer matched. Every node produced a garbage key, `nodeInfo[key]` was always `undefined`, and all nodes were skipped — no tooltips.

## Fix

Replace the brittle anchored `replace` with `id.match(/flowchart-(.+?)-\d+$/)`, which extracts the node key (`ON1`, `CONSUL`, `GRAFANA`, …) from **both** the Mermaid 11 and legacy id forms. Verified against real rendered ids.

## Notes

- Docs/web-only change (no Go files), so no `.version` bump required and no manual CHANGELOG edit (git-cliff generates it at release).
- The page pulls Mermaid from a floating `@11` CDN tag; the new regex tolerates structural shifts, but pinning a specific version is a possible follow-up.