### PR TITLE
build(release): use monotonic snapshot version template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,18 @@
 
 version: 2
 
+# --- Snapshot builds (`goreleaser --snapshot`, i.e. `make deb`) get published to
+#     the aptly repo, so their versions MUST increase monotonically or apt won't
+#     upgrade nodes. The default snapshot version ends in the git short-commit,
+#     which dpkg compares LEXICALLY (not by build time) -- so rebuilds of the same
+#     base version look "older" at random and `apt-get upgrade` skips them.
+#     Fix: `incpatch` bumps to the next patch (sorts above the last release), the
+#     `~snapshot` keeps it a pre-release of that patch, and the Unix build
+#     `.Timestamp` strictly increases on every build -> reliable, ordered upgrades.
+#     e.g. base 1.4.8 -> 1.4.9~snapshot.1751520000
+snapshot:
+  version_template: '{{ incpatch .Version }}~snapshot.{{ .Timestamp }}'
+
 builds:
   - main: ./cmd/watchdog
     binary: oracle-watchdog


### PR DESCRIPTION
Snapshot builds (`make deb`) publish to the aptly repo, so their versions must increase monotonically or apt won't upgrade nodes.

**Problem:** the default snapshot version ends in the git short-commit, which `dpkg` compares *lexically* (not by build time). Rebuilds of the same base version sort inconsistently, so `apt-get upgrade` skips them at random.

**Fix:** `{{ incpatch .Version }}~snapshot.{{ .Timestamp }}`
- `incpatch` bumps to the next patch so snapshots sort *above* the last release
- `~snapshot` keeps it a pre-release of that patch
- Unix `.Timestamp` strictly increases on every build

Verified: base `1.4.8` renders `1.4.9~snapshot.1784449002`; `goreleaser check` passes and a snapshot build succeeds.

No Go files touched, so no `.version` bump needed.